### PR TITLE
修复Android激励视频观看结束后，点击关闭没有往前端回传值的 bug

### DIFF
--- a/android/src/main/java/com/haxifang/ad/RewardVideo.java
+++ b/android/src/main/java/com/haxifang/ad/RewardVideo.java
@@ -41,6 +41,7 @@ public class RewardVideo extends ReactContextBaseJavaModule {
             // 上下文未初始化，跳出加载广告方法，避免闪退问题
             return;
         }
+        TTAdManagerHolder.setPromise(promise);
         String appid = options.hasKey("appid") ? options.getString("appid") : null;
         String codeid = options.hasKey("codeid") ? options.getString("codeid") : null;
         // Log.d(TAG, "startAd:  appid: " + appid + ", codeid: " + codeid);

--- a/src/RewardVideo.ts
+++ b/src/RewardVideo.ts
@@ -12,6 +12,7 @@ interface EVENT_TYPE {
 	onAdLoaded: string; // 广告加载成功监听
 	onAdClick: string; // 广告被点击监听
 	onAdClose: string; // 广告关闭监听
+	onVideoComplete: string; // 广告播放完成监听
 }
 
 export default function ({ appid, codeid }) {


### PR DESCRIPTION
# 修复Android激励视频观看结束后，点击关闭没有往前端回传值的 bug
原因是没有对 `promise` 进行初始化设置

```
TTAdManagerHolder.setPromise(promise);
```
# 添加 `onVideoComplete` 事件回调

```
interface EVENT_TYPE {
	onAdError: string; // 广告加载失败监听
	onAdLoaded: string; // 广告加载成功监听
	onAdClick: string; // 广告被点击监听
	onAdClose: string; // 广告关闭监听
	onVideoComplete: string; // 广告播放完成监听
}

```