### PR TITLE
修复了激励视频的一些问题

### DIFF
--- a/android/src/main/java/com/haxifang/ad/RewardVideo.java
+++ b/android/src/main/java/com/haxifang/ad/RewardVideo.java
@@ -41,6 +41,7 @@ public class RewardVideo extends ReactContextBaseJavaModule {
             // 上下文未初始化，跳出加载广告方法，避免闪退问题
             return;
         }
+        TTAdManagerHolder.setPromise(promise);
         String appid = options.hasKey("appid") ? options.getString("appid") : null;
         String codeid = options.hasKey("codeid") ? options.getString("codeid") : null;
         // Log.d(TAG, "startAd:  appid: " + appid + ", codeid: " + codeid);

--- a/android/src/main/java/com/haxifang/ad/activities/RewardActivity.java
+++ b/android/src/main/java/com/haxifang/ad/activities/RewardActivity.java
@@ -199,6 +199,8 @@ public class RewardActivity extends Activity {
 
             @Override
             public void onVideoError() {
+                // 当视频播放出错时，video_play 应为 false
+                is_show = true;
                 // TToast.show(_this, "奖励视频出错了...");
                 RNCallBack("onAdError", 1004, "激励视频播放出错了");
             }

--- a/src/RewardVideo.ts
+++ b/src/RewardVideo.ts
@@ -12,6 +12,7 @@ interface EVENT_TYPE {
 	onAdLoaded: string; // 广告加载成功监听
 	onAdClick: string; // 广告被点击监听
 	onAdClose: string; // 广告关闭监听
+	onVideoComplete: string; // 广告播放完成监听
 }
 
 export default function ({ appid, codeid }) {


### PR DESCRIPTION
根据文档

```

激励视频除了通过监听事件取得回调还有一个更加稳妥的回调操作获取方式通过 Promise 异步获取用户对激励视频的关键操作，将获取一个 json 数据对应相关的 boolean 值：video_play（视频是否播放完），ad_click（用户是否点击广告），apk_install（用户是否安装广告应用），verify_status（认证激励状态）

```

`video_play` 为是否播放完成，那么应该在视频播放出错的回调中处理为 `false`